### PR TITLE
Rename variables and use double mutex in StopConsumer

### DIFF
--- a/MediaSoupTransceiver.cpp
+++ b/MediaSoupTransceiver.cpp
@@ -32,7 +32,7 @@
 
 MediaSoupTransceiver::MediaSoupTransceiver() 
 {
-	m_producerMailbox = std::make_unique<MediaSoupMailbox>();
+	m_producerMailbox = std::make_shared<MediaSoupMailbox>();
 }
 
 MediaSoupTransceiver::~MediaSoupTransceiver()
@@ -42,7 +42,7 @@ MediaSoupTransceiver::~MediaSoupTransceiver()
 
 bool MediaSoupTransceiver::LoadDevice(json& routerRtpCapabilities, json& output_deviceRtpCapabilities, json& output_deviceSctpCapabilities)
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	if (m_device != nullptr)
 	{
@@ -168,7 +168,7 @@ rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> MediaSoupTransceiver:
 
 bool MediaSoupTransceiver::CreateReceiver(const std::string& recvTransportId, const json& iceParameters, const json& iceCandidates, const json& dtlsParameters, nlohmann::json* sctpParameters /*= nullptr*/, nlohmann::json* iceServers /*= nullptr*/)
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	if (m_recvTransport != nullptr)
 	{
@@ -226,7 +226,7 @@ bool MediaSoupTransceiver::CreateReceiver(const std::string& recvTransportId, co
 
 bool MediaSoupTransceiver::CreateSender(const std::string& id, const json& iceParameters, const json& iceCandidates, const json& dtlsParameters, nlohmann::json* iceServers /*= nullptr*/)
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	if (m_sendTransport != nullptr)
 	{
@@ -275,7 +275,7 @@ bool MediaSoupTransceiver::CreateSender(const std::string& id, const json& icePa
 
 bool MediaSoupTransceiver::CreateVideoProducerTrack(const nlohmann::json* ecodings /*= nullptr*/, const nlohmann::json* codecOptions /*= nullptr*/, const nlohmann::json* codec /*= nullptr*/)
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	if (m_device == nullptr)
 	{
@@ -348,7 +348,7 @@ rtc::scoped_refptr<webrtc::VideoTrackInterface> MediaSoupTransceiver::CreateProd
 
 bool MediaSoupTransceiver::CreateAudioProducerTrack()
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	if (m_device == nullptr)
 	{
@@ -417,7 +417,7 @@ rtc::scoped_refptr<webrtc::AudioTrackInterface> MediaSoupTransceiver::CreateProd
 
 bool MediaSoupTransceiver::CreateAudioConsumer(const std::string& id, const std::string& producerId, json* rtpParameters, obs_source_t* source)
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	if (m_device == nullptr)
 	{
@@ -438,7 +438,7 @@ bool MediaSoupTransceiver::CreateAudioConsumer(const std::string& id, const std:
 	}
 
 	auto audioSink = std::make_unique<MyAudioSink>();
-	audioSink->m_mailbox = std::make_unique<MediaSoupMailbox>();
+	audioSink->m_mailbox = std::make_shared<MediaSoupMailbox>();
 	audioSink->m_consumerType = MediaSoupTransceiver::ConsumerType::ConsumerAudio;
 	audioSink->m_obs_source = source;
 
@@ -451,7 +451,7 @@ bool MediaSoupTransceiver::CreateAudioConsumer(const std::string& id, const std:
 
 bool MediaSoupTransceiver::CreateVideoConsumer(const std::string& id, const std::string& producerId, json* rtpParameters)
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	if (m_device == nullptr)
 	{
@@ -472,7 +472,7 @@ bool MediaSoupTransceiver::CreateVideoConsumer(const std::string& id, const std:
 	}
 	
 	auto videoSink = std::make_unique<MyVideoSink>();
-	videoSink->m_mailbox = std::make_unique<MediaSoupMailbox>();
+	videoSink->m_mailbox = std::make_shared<MediaSoupMailbox>();
 	videoSink->m_consumerType = MediaSoupTransceiver::ConsumerType::ConsumerAudio;
 
 	auto trackRaw = consumer->GetTrack();
@@ -554,7 +554,7 @@ void MediaSoupTransceiver::AudioThread()
 
 void MediaSoupTransceiver::StopReceiveTransport()
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	if (m_recvTransport)
 		m_recvTransport->Close();
@@ -587,7 +587,7 @@ void MediaSoupTransceiver::StopReceiveTransport()
 
 void MediaSoupTransceiver::StopSendTransport()
 {	
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	m_sendingAudio = false;
 
@@ -630,7 +630,7 @@ void MediaSoupTransceiver::StopSendTransport()
                                                                             
 void MediaSoupTransceiver::Stop()
 {
-	std::lock_guard<std::mutex> grd(m_externalMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
 
 	m_sendingAudio = false;
 
@@ -784,11 +784,22 @@ void MediaSoupTransceiver::AssignConsumer(const std::string& id, mediasoupclient
 	}
 
 	std::lock_guard<std::recursive_mutex> grd(m_consumerMutex);
-	StopConsumerById(id);
+
+	auto itr = m_dataConsumers.find(id);
+
+	if (itr != m_dataConsumers.end())
+	{
+		if (itr->second.first != nullptr)
+			itr->second.first->Close();
+
+		delete itr->second.first;
+		itr = m_dataConsumers.erase(itr);
+	}
+
 	m_dataConsumers[id] = { value, std::move(sink) };
 }
 
-MediaSoupMailbox* MediaSoupTransceiver::GetConsumerMailbox(const std::string& id)
+std::shared_ptr<MediaSoupMailbox> MediaSoupTransceiver::GetConsumerMailbox(const std::string& id)
 {
 	std::lock_guard<std::recursive_mutex> grd(m_consumerMutex);
 
@@ -797,7 +808,7 @@ MediaSoupMailbox* MediaSoupTransceiver::GetConsumerMailbox(const std::string& id
 	if (itr != m_dataConsumers.end())
 	{
 		if (itr->second.first != nullptr)
-			return itr->second.second->m_mailbox.get();
+			return itr->second.second->m_mailbox;
 	}
 
 	return nullptr;
@@ -805,7 +816,8 @@ MediaSoupMailbox* MediaSoupTransceiver::GetConsumerMailbox(const std::string& id
 
 void MediaSoupTransceiver::StopConsumerById(const std::string& id)
 {
-	std::lock_guard<std::recursive_mutex> grd(m_consumerMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
+	std::lock_guard<std::recursive_mutex> grd2(m_consumerMutex);
 
 	auto itr = m_dataConsumers.find(id);
 
@@ -821,7 +833,8 @@ void MediaSoupTransceiver::StopConsumerById(const std::string& id)
 
 std::string MediaSoupTransceiver::StopConsumerByProducerId(const std::string& id)
 {
-	std::lock_guard<std::recursive_mutex> grd(m_consumerMutex);
+	std::lock_guard<std::mutex> grd(m_transportMutex);
+	std::lock_guard<std::recursive_mutex> grd2(m_consumerMutex);
 	std::string result;
 
 	for (auto itr = m_dataConsumers.begin(); itr != m_dataConsumers.end();)
@@ -886,16 +899,19 @@ void MediaSoupTransceiver::OnTransportClose(mediasoupclient::Producer* producer)
 
 bool MediaSoupTransceiver::AudioProducerReady()
 {
+	std::lock_guard<std::recursive_mutex> grd(m_producerMutex);
 	return SenderConnected() && m_dataProducer_Audio != nullptr;
 }
 
 bool MediaSoupTransceiver::VideoProducerReady()
 {
+	std::lock_guard<std::recursive_mutex> grd(m_producerMutex);
 	return SenderConnected() && m_dataProducer_Video != nullptr;
 }
 
 bool MediaSoupTransceiver::ConsumerReady(const std::string& id)
 {
+	std::lock_guard<std::recursive_mutex> grd(m_consumerMutex);
 	return SenderConnected() && m_dataConsumers[id].first != nullptr;
 }
 
@@ -903,6 +919,8 @@ bool MediaSoupTransceiver::ConsumerReadyAtLeastOne()
 {
 	if (!SenderConnected())
 		return false;
+	
+	std::lock_guard<std::recursive_mutex> grd(m_consumerMutex);
 
 	for (auto& itr : m_dataConsumers)
 	{

--- a/MediaSoupTransceiver.h
+++ b/MediaSoupTransceiver.h
@@ -125,7 +125,7 @@ private:
 	std::atomic<bool> m_sendingAudio{ false };
 	
 	std::mutex m_stateMutex;
-	std::mutex m_transportMutex;
+	std::recursive_mutex m_transportMutex;
 
 	std::unique_ptr<mediasoupclient::Device> m_device;
 

--- a/MediaSoupTransceiver.h
+++ b/MediaSoupTransceiver.h
@@ -75,8 +75,8 @@ public:
 	// Returns the ID of the consumer that was stopped
 	std::string StopConsumerByProducerId(const std::string& id);
 
-	MediaSoupMailbox* GetConsumerMailbox(const std::string& id);
-	MediaSoupMailbox* GetProducerMailbox() { return m_producerMailbox.get(); }
+	std::shared_ptr<MediaSoupMailbox> GetConsumerMailbox(const std::string& id);
+	std::shared_ptr<MediaSoupMailbox> GetProducerMailbox() { return m_producerMailbox; }
 	mediasoupclient::Device* GetDevice() const { return m_device.get(); }
 
 	const std::string GetSenderId();
@@ -125,7 +125,7 @@ private:
 	std::atomic<bool> m_sendingAudio{ false };
 	
 	std::mutex m_stateMutex;
-	std::mutex m_externalMutex;
+	std::mutex m_transportMutex;
 
 	std::unique_ptr<mediasoupclient::Device> m_device;
 
@@ -141,7 +141,7 @@ private:
 	public:
 		virtual ~GenericSink() {}
 		ConsumerType m_consumerType;
-		std::unique_ptr<MediaSoupMailbox> m_mailbox;
+		std::shared_ptr<MediaSoupMailbox> m_mailbox;
 		obs_source_t* m_obs_source{ nullptr };
 	};
 
@@ -160,7 +160,7 @@ private:
 	rtc::scoped_refptr<MyProducerAudioDeviceModule> m_MyProducerAudioDeviceModule;
 	rtc::scoped_refptr<webrtc::AudioDeviceModule> m_DefaultDeviceCore;
 	std::unique_ptr<webrtc::TaskQueueFactory> m_DefaultDeviceCore_TaskQueue;
-	std::unique_ptr<MediaSoupMailbox> m_producerMailbox;
+	std::shared_ptr<MediaSoupMailbox> m_producerMailbox;
 
 // Producer
 private:


### PR DESCRIPTION
Double mutex is already an existing requirement because of WebRTC/mediasoup's architecture.
This change locks both when stopping a consumer, to ensure that the transport and consumers are always in sync

Renames:

- The "m_externalMutex" has been renamed to "m_transportMutex" to more accurately describe it's purpose
- The mailbox is now a shared pointer for safety purposes. In the event that a stale mailbox is returned by GetConsumerMailbox, the effects will be totally benign
- Transport mutex changed to recursive to allow internal use of StopConsumerById