### PR TITLE
Revise webrtc LogSink cleanup

### DIFF
--- a/MyLogSink.cpp
+++ b/MyLogSink.cpp
@@ -2,16 +2,14 @@
 
 #include "MyLogSink.h"
 
-// This is a singleton
-MyLogSink::MyLogSink()
+void MyLogSink::Start()
 {
 	rtc::LogMessage::AddLogToStream(this, rtc::WARNING);
 }
 
-MyLogSink::~MyLogSink()
+void MyLogSink::Stop()
 {
-	// We're a singleton so if we go away then webrtc has as well so I think this is redundant... ??
-	//rtc::LogMessage::RemoveLogToStream(this);
+	rtc::LogMessage::RemoveLogToStream(this);
 }
 
 void MyLogSink::OnLogMessage(const std::string& message, rtc::LoggingSeverity severity)

--- a/MyLogSink.h
+++ b/MyLogSink.h
@@ -7,7 +7,8 @@
 class MyLogSink : public rtc::LogSink
 {
 public:
-	~MyLogSink();
+	void Start();
+	void Stop();
 
 	static MyLogSink& instance()
 	{
@@ -20,5 +21,5 @@ protected:
 	void OnLogMessage(const std::string& message, rtc::LoggingSeverity severity) final;
 
 private:
-	MyLogSink();
+	MyLogSink() { }
 };

--- a/mediasoup-connector.cpp
+++ b/mediasoup-connector.cpp
@@ -47,10 +47,8 @@ static void* msoup_create(obs_data_t* settings, obs_source_t* source)
 
 	obs_source_set_audio_active(source, true);
 
-	// Captures webrtc debug msgs
-	MyLogSink::instance();
-	
-	++MediaSoupInterface::instance().m_sourceCounter;
+	if (++MediaSoupInterface::instance().m_sourceCounter == 1)
+		MyLogSink::instance().Start();
 	
 	return data;
 }
@@ -69,7 +67,10 @@ static void msoup_destroy(void* data)
 
 	// We're the last one, final cleanup
 	if (MediaSoupInterface::instance().m_sourceCounter <= 0)
+	{
 		MediaSoupInterface::instance().reset();
+		MyLogSink::instance().Stop();
+	}
 
 	delete sourceInfo;
 }


### PR DESCRIPTION
Previous behavior was undefined, attempting to fix a shutdown crash by cleaning up before the program begins to unwind