### PR TITLE
Consumers/Producers can sometimes throw during Close

### DIFF
--- a/MediaSoupTransceiver.h
+++ b/MediaSoupTransceiver.h
@@ -106,6 +106,8 @@ public:
 private:
 	void Stop();
 	void AudioThread();
+	void TryClose(mediasoupclient::Producer* producer);
+	void TryClose(mediasoupclient::Consumer* dataConsumer);
 
 	std::string GetConnectionState(mediasoupclient::Transport* transport);
 


### PR DESCRIPTION
The code inside mediasoup indicates in the comments "May throw", presumably if the object wasn't actually connected. 