### PR TITLE
Fix Collab Cam transceiver singleton drift across socket reconnects

### DIFF
--- a/ConnectorFrontApi.cpp
+++ b/ConnectorFrontApi.cpp
@@ -49,6 +49,14 @@ void ConnectorFrontApi::func_stop_producer(void *data, calldata_t *cd)
 	MediaSoupInterface::instance().getTransceiver()->StopProducerById(input);
 }
 
+void ConnectorFrontApi::func_reset_device(void *data, calldata_t *cd)
+{
+	UNUSED_PARAMETER(data);
+	UNUSED_PARAMETER(cd);
+	blog(LOG_WARNING, "func_reset_device");
+	MediaSoupInterface::instance().reset();
+}
+
 void ConnectorFrontApi::func_connect_result(void *data, calldata_t *cd)
 {
 	std::string input = calldata_string(cd, "input");

--- a/ConnectorFrontApi.h
+++ b/ConnectorFrontApi.h
@@ -20,6 +20,7 @@ struct ConnectorFrontApi {
 	static void func_stop_sender(void *data, calldata_t *cd);
 	static void func_stop_consumer(void *data, calldata_t *cd);
 	static void func_stop_producer(void *data, calldata_t *cd);
+	static void func_reset_device(void *data, calldata_t *cd);
 };
 
 struct ConnectorFrontApiHelper {

--- a/MediaSoupTransceiver.cpp
+++ b/MediaSoupTransceiver.cpp
@@ -41,9 +41,18 @@ bool MediaSoupTransceiver::LoadDevice(json &routerRtpCapabilities, json &output_
 {
 	std::lock_guard<std::recursive_mutex> grd(m_transportMutex);
 
+	// Idempotent: if the device is already loaded (e.g. JS reissued func_load_device
+	// on a socket reconnect within the same Collab Cam session), return the existing
+	// capabilities instead of erroring. A truly fresh device requires func_reset_device.
 	if (m_device != nullptr) {
-		m_lastErorMsg = "Device already exists";
-		return false;
+		try {
+			output_deviceRtpCapabilities = m_device->GetRtpCapabilities();
+			output_deviceSctpCapabilities = m_device->GetSctpCapabilities();
+		} catch (...) {
+			m_lastErorMsg = "Failed to read existing mediasoupclient::Device capabilities";
+			return false;
+		}
+		return true;
 	}
 
 	m_device = std::make_unique<mediasoupclient::Device>();
@@ -508,8 +517,16 @@ void MediaSoupTransceiver::StopReceiveTransport()
 		}
 	}
 
-	while (ReceiverConnected())
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	{
+		const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+		while (ReceiverConnected()) {
+			if (std::chrono::steady_clock::now() >= deadline) {
+				blog(LOG_WARNING, "StopReceiveTransport: receive transport did not leave 'completed' state within 2s; proceeding with delete");
+				break;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		}
+	}
 
 	delete m_recvTransport;
 	m_recvTransport = nullptr;
@@ -545,8 +562,16 @@ void MediaSoupTransceiver::StopSendTransport()
 		m_dataProducers.clear();
 	}
 
-	while (SenderConnected())
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	{
+		const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+		while (SenderConnected()) {
+			if (std::chrono::steady_clock::now() >= deadline) {
+				blog(LOG_WARNING, "StopSendTransport: send transport did not leave 'completed' state within 2s; proceeding with delete");
+				break;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		}
+	}
 
 	delete m_sendTransport;
 	m_sendTransport = nullptr;

--- a/mediasoup-connector.cpp
+++ b/mediasoup-connector.cpp
@@ -53,6 +53,7 @@ static void *msoup_create(obs_data_t *settings, obs_source_t *source)
 	proc_handler_add(ph, "void func_stop_sender(in string input, out string output)", ConnectorFrontApi::func_stop_sender, data);
 	proc_handler_add(ph, "void func_stop_consumer(in string input, out string output)", ConnectorFrontApi::func_stop_consumer, data);
 	proc_handler_add(ph, "void func_stop_producer(in string input, out string output)", ConnectorFrontApi::func_stop_producer, data);
+	proc_handler_add(ph, "void func_reset_device(in string input, out string output)", ConnectorFrontApi::func_reset_device, data);
 
 	obs_source_set_audio_active(source, true);
 


### PR DESCRIPTION
## Summary
- `MediaSoupTransceiver::LoadDevice` is now idempotent — when the singleton already holds a device (e.g. JS reissues `func_load_device` on a socket reconnect within the same Collab Cam session), return the existing capabilities instead of erroring with `Device already exists`.
- Add `func_reset_device` proc that calls the existing `MediaSoupInterface::reset()` so the JS feature-teardown path can fully recycle the singleton between sessions.
- Bound the busy-waits in `StopReceiveTransport` / `StopSendTransport` at 2 s with a warning log on timeout, then proceed to `delete`. Eliminates the 15 s `Source::CallHandler` IPC freeze that recurred for affected users when a transport stalled mid-teardown.

## Context
Diagnosed from two independent SLD 1.20.9 support tickets ("Guests on Collab Cam are disconnecting after a few minutes"). Both diagnostics showed the same fingerprint in `node-obs/logs/*.txt`:
- `msoup_create LoadDevice failed error = 'Device already exists'` repeating across every socket reconnect within a single session (5× and 21× respectively)
- WebRTC state-drift symptoms: `Failed to send packet, matching RTP module not found or transport error` and floods of `jsep_transport_controller.cc:300: Not adding candidate because the JsepTransport doesn't exist`
- 15 s `(freeze) Source::CallHandler` entries in `long_calls.txt` lining up with transport teardown

Root cause: `MediaSoupInterface` is a process-lifetime singleton. `LoadDevice` early-returned if `m_device != nullptr`. The only path that nulled `m_device` was `Stop()`, called only from `~MediaSoupTransceiver`, which only ran when the singleton's `reset()` replaced the unique_ptr — and `reset()` was previously called only from `msoup_destroy` (last source removed = full feature disable) or `~MediaSoupInterface` (process exit). Meanwhile the JS calls `func_load_device` unconditionally on every socket `connect` event, so state drifted across reconnects until restart.

The JS side will call the new `func_reset_device` from `cleanUpSocketConnection()` so reset happens on full Collab Cam teardown without disturbing transient socket-reconnect paths. JS change ships in a sibling PR on `streamlabs/desktop`.

## Test plan
- [ ] CMake builds the plugin cleanly: `cmake --build --preset windows-x64 --config RelWithDebInfo`
- [ ] Install into local `obs-studio-node/build/libobs-src/` and run desktop with `yarn start`
- [ ] Host a Collab Cam session with a guest joining from a different machine, force a few socket reconnects, confirm:
  - Zero `Device already exists` lines in `node-obs/logs/*.txt`
  - Zero `(freeze) Source::CallHandler` in `long_calls.txt` near transport stops
  - Zero `did not leave 'completed' state within 2s` warnings (or if present, they fire cleanly without hanging)
- [ ] Disable Collab Cam mid-session, confirm `func_reset_device` + `resetThreadCache` appear in native log
- [ ] Re-enable Collab Cam, confirm a fresh `createInterfaceObject start` + full `func_create_send_transport` / `func_create_receive_transport` / consumer setup sequence on the new transceiver
- [ ] Two end-to-end host+guest sessions back-to-back stay healthy across the reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)