### PR TITLE
Upgrade to libmediasoupclient 3.5.0 + libwebrtc M140

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ target_link_libraries(webrtc-testlibs
 
 set_property(TARGET webrtc-testlibs PROPERTY CXX_STANDARD 20)
 set_property(TARGET webrtc-testlibs PROPERTY CXX_STANDARD_REQUIRED ON)
+# Third-party webrtc test sources: /WX- above is overridden by CMAKE_COMPILE_WARNING_AS_ERROR, so disable per-target.
+set_property(TARGET webrtc-testlibs PROPERTY COMPILE_WARNING_AS_ERROR OFF)
 
 target_compile_definitions(webrtc-testlibs PUBLIC ${webrtc_COMMON_COMPILE_DEFS})
 
@@ -145,6 +147,9 @@ add_library(mediasoup-connector MODULE
 	${mediasoup-connector_SOURCES})
 
 add_library(OBS::mediasoup-connector ALIAS mediasoup-connector)
+
+# Includes webrtc headers (e.g. divide_round.h -> C4146); /WX- is overridden by CMAKE_COMPILE_WARNING_AS_ERROR.
+set_property(TARGET mediasoup-connector PROPERTY COMPILE_WARNING_AS_ERROR OFF)
 
 if(MSVC)
 	target_compile_options(mediasoup-connector PRIVATE "$<IF:$<CONFIG:Debug>,/MTd,/MT>" /wd4100)

--- a/ConnectorFrontApiHelper.cpp
+++ b/ConnectorFrontApiHelper.cpp
@@ -47,6 +47,7 @@ bool ConnectorFrontApiHelper::createReceiver(const std::string &params, calldata
 
 bool ConnectorFrontApiHelper::createSender(const std::string &params, calldata_t *cd)
 {
+	blog(LOG_WARNING, "ConnectorFrontApiHelper::createSender called");
 	blog(LOG_DEBUG, "createSender start");
 
 	if (MediaSoupInterface::instance().getTransceiver()->SenderCreated()) {
@@ -297,6 +298,7 @@ bool ConnectorFrontApiHelper::createProducerTrack(const std::string &kind, calld
 
 bool ConnectorFrontApiHelper::createAudioProducerTrack(calldata_t *cd, const std::string &input)
 {
+	blog(LOG_WARNING, "ConnectorFrontApiHelper::createAudioProducerTrack called");
 	blog(LOG_DEBUG, "createAudioProducerTrack start");
 
 	if (!MediaSoupInterface::instance().getTransceiver()->SenderCreated()) {
@@ -309,6 +311,7 @@ bool ConnectorFrontApiHelper::createAudioProducerTrack(calldata_t *cd, const std
 
 bool ConnectorFrontApiHelper::createVideoProducerTrack(calldata_t *cd, const std::string &input)
 {
+	blog(LOG_WARNING, "ConnectorFrontApiHelper::createVideoProducerTrack called");
 	blog(LOG_DEBUG, "createVideoProducerTrack start");
 
 	if (!MediaSoupInterface::instance().getTransceiver()->SenderCreated()) {

--- a/MediaSoupInterface.cpp
+++ b/MediaSoupInterface.cpp
@@ -24,6 +24,7 @@ MediaSoupInterface::~MediaSoupInterface()
 
 void MediaSoupInterface::reset()
 {
+	blog(LOG_WARNING, "MediaSoupInterface::reset() called — recreating transceiver and clearing all waiting state");
 	resetThreadCache();
 
 	if (m_connectionThread != nullptr && m_connectionThread->joinable())
@@ -97,6 +98,7 @@ void MediaSoupInterface::joinWaitingThread()
 
 void MediaSoupInterface::resetThreadCache()
 {
+	blog(LOG_WARNING, "MediaSoupInterface::resetThreadCache() called");
 	m_connectWaiting = false;
 	m_produceWaiting = false;
 	m_threadInProgress = false;

--- a/MediaSoupMailbox.cpp
+++ b/MediaSoupMailbox.cpp
@@ -167,7 +167,11 @@ void MediaSoupMailbox::pop_outgoing_audioFrames(std::vector<std::unique_ptr<Soup
 			if (audio_resampler_resample(m_to_mediasoup_resampler, array2d_int16_raw, &numFrames, &tOffset, array2d_float_planar_raw,
 						     framesPer10ms)) {
 				ptr->audio_data.resize(framesPer10ms * m_obs_numChannels);
-				webrtc::Interleave((int16_t **)array2d_int16_raw, ptr->numFrames, ptr->numChannels, ptr->audio_data.data());
+				for (int ch = 0; ch < ptr->numChannels; ++ch) {
+				const int16_t *src = ((int16_t **)array2d_int16_raw)[ch];
+				for (int f = 0; f < ptr->numFrames; ++f)
+					ptr->audio_data[f * ptr->numChannels + ch] = src[f];
+			}
 			}
 		}
 
@@ -184,7 +188,11 @@ void MediaSoupMailbox::pop_outgoing_audioFrames(std::vector<std::unique_ptr<Soup
 			if (audio_resampler_resample(m_from_float_to_mediasoup_resampler, array2d_int16_raw, &numFrames, &tOffset, array2d_float_raw,
 						     framesPer10ms)) {
 				ptr->audio_data.resize(framesPer10ms * m_obs_numChannels);
-				webrtc::Interleave((int16_t **)array2d_int16_raw, ptr->numFrames, ptr->numChannels, ptr->audio_data.data());
+				for (int ch = 0; ch < ptr->numChannels; ++ch) {
+				const int16_t *src = ((int16_t **)array2d_int16_raw)[ch];
+				for (int f = 0; f < ptr->numFrames; ++f)
+					ptr->audio_data[f * ptr->numChannels + ch] = src[f];
+			}
 			}
 		}
 

--- a/MediaSoupTransceiver.cpp
+++ b/MediaSoupTransceiver.cpp
@@ -7,6 +7,9 @@
 #include "ConnectorFrontApi.h"
 
 #include "api/create_peerconnection_factory.h"
+#include "api/audio/create_audio_device_module.h"
+#include "api/environment/environment.h"
+#include "api/environment/environment_factory.h"
 #include "api/audio_codecs/builtin_audio_decoder_factory.h"
 #include "api/audio_codecs/builtin_audio_encoder_factory.h"
 #include "api/video_codecs/builtin_video_decoder_factory.h"
@@ -98,7 +101,7 @@ rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> MediaSoupTransceiver:
 		return nullptr;
 	}
 
-	m_MyProducerAudioDeviceModule = new rtc::RefCountedObject<MyProducerAudioDeviceModule>{};
+	m_MyProducerAudioDeviceModule = webrtc::make_ref_counted<MyProducerAudioDeviceModule>();
 
 	auto factory = webrtc::CreatePeerConnectionFactory(m_networkThread_Producer.get(), m_workerThread_Producer.get(), m_signalingThread_Producer.get(),
 							   m_MyProducerAudioDeviceModule, webrtc::CreateBuiltinAudioEncoderFactory(),
@@ -129,8 +132,8 @@ rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> MediaSoupTransceiver:
 	}
 
 	std::thread thr([&]() {
-		m_DefaultDeviceCore_TaskQueue = webrtc::CreateDefaultTaskQueueFactory();
-		m_DefaultDeviceCore = webrtc::AudioDeviceModule::Create(webrtc::AudioDeviceModule::kPlatformDefaultAudio, m_DefaultDeviceCore_TaskQueue.get());
+		webrtc::Environment env = webrtc::CreateEnvironment();
+		m_DefaultDeviceCore = webrtc::CreateAudioDeviceModule(env, webrtc::AudioDeviceModule::kPlatformDefaultAudio);
 	});
 
 	thr.join();
@@ -295,12 +298,11 @@ rtc::scoped_refptr<webrtc::VideoTrackInterface>
 MediaSoupTransceiver::CreateProducerVideoTrack(rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory, const std::string &label,
 					       std::shared_ptr<MediaSoupMailbox> ptr)
 {
-	// The factory handles cleanup of this cstyle pointer
-	auto videoTrackSource = new rtc::RefCountedObject<FrameGeneratorCapturerVideoTrackSource>(FrameGeneratorCapturerVideoTrackSource::Config(),
+	auto videoTrackSource = webrtc::make_ref_counted<FrameGeneratorCapturerVideoTrackSource>(FrameGeneratorCapturerVideoTrackSource::Config(),
 												  webrtc::Clock::GetRealTimeClock(), false, ptr);
 	videoTrackSource->Start();
 
-	return factory->CreateVideoTrack(rtc::CreateRandomUuid(), videoTrackSource);
+	return factory->CreateVideoTrack(videoTrackSource, rtc::CreateRandomUuid());
 }
 
 bool MediaSoupTransceiver::CreateAudioProducerTrack(const std::string &id)
@@ -928,7 +930,7 @@ void MediaSoupTransceiver::MyVideoSink::OnFrame(const webrtc::VideoFrame &video_
 }
 
 void MediaSoupTransceiver::MyAudioSink::OnData(const void *audio_data, int bits_per_sample, int sample_rate, size_t number_of_channels, size_t number_of_frames,
-					       absl::optional<int64_t> absolute_capture_timestamp_ms)
+					       std::optional<int64_t> absolute_capture_timestamp_ms)
 {
 	size_t number_of_bytes = 0;
 

--- a/MediaSoupTransceiver.cpp
+++ b/MediaSoupTransceiver.cpp
@@ -206,6 +206,7 @@ bool MediaSoupTransceiver::CreateSender(const std::string &id, const json &icePa
 	std::lock_guard<std::recursive_mutex> grd(m_transportMutex);
 
 	if (m_sendTransport != nullptr) {
+		blog(LOG_WARNING, "MediaSoupTransceiver::CreateSender - Send transport ALREADY EXISTS");
 		m_lastErorMsg = "Send transport already exists";
 		return false;
 	}
@@ -440,6 +441,7 @@ bool MediaSoupTransceiver::CreateVideoConsumer(const std::string &id, const std:
 // Update the already created remote transport with the local DTLS parameters.
 std::future<void> MediaSoupTransceiver::OnConnect(mediasoupclient::Transport *transport, const json &dtlsParameters)
 {
+	blog(LOG_WARNING, "MediaSoupTransceiver::OnConnect called (transportId=%s)", transport->GetId().c_str());
 	std::promise<void> promise;
 
 	if ((m_recvTransport && transport->GetId() == m_recvTransport->GetId()) || (m_sendTransport && transport->GetId() == m_sendTransport->GetId())) {
@@ -461,6 +463,7 @@ std::future<void> MediaSoupTransceiver::OnConnect(mediasoupclient::Transport *tr
 std::future<std::string> MediaSoupTransceiver::OnProduce(mediasoupclient::SendTransport *transport, const std::string &kind, nlohmann::json rtpParameters,
 							 const nlohmann::json &appData)
 {
+	blog(LOG_WARNING, "MediaSoupTransceiver::OnProduce called (kind=%s)", kind.c_str());
 	std::promise<std::string> promise;
 	std::string value;
 

--- a/MediaSoupTransceiver.h
+++ b/MediaSoupTransceiver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "webrtc_compat.h"
+
 #include "Device.hpp"
 #include "Logger.hpp"
 
@@ -154,7 +156,7 @@ private:
 	class MyAudioSink : public webrtc::AudioTrackSinkInterface, public GenericSink {
 	public:
 		void OnData(const void *audio_data, int bits_per_sample, int sample_rate, size_t number_of_channels, size_t number_of_frames,
-			    absl::optional<int64_t> absolute_capture_timestamp_ms) override;
+			    std::optional<int64_t> absolute_capture_timestamp_ms) override;
 	};
 
 	class MyVideoSink : public rtc::VideoSinkInterface<webrtc::VideoFrame>, public GenericSink {
@@ -164,7 +166,6 @@ private:
 
 	rtc::scoped_refptr<MyProducerAudioDeviceModule> m_MyProducerAudioDeviceModule;
 	rtc::scoped_refptr<webrtc::AudioDeviceModule> m_DefaultDeviceCore;
-	std::unique_ptr<webrtc::TaskQueueFactory> m_DefaultDeviceCore_TaskQueue;
 
 	// Producer
 private:

--- a/MyFrameGeneratorInterface.cpp
+++ b/MyFrameGeneratorInterface.cpp
@@ -25,12 +25,12 @@ webrtc::test::FrameGeneratorInterface::VideoFrameData MyFrameGeneratorInterface:
 	if (!frames.empty())
 		m_lastFrame = frames[frames.size() - 1];
 
-	return VideoFrameData(m_lastFrame, absl::nullopt);
+	return VideoFrameData(m_lastFrame, std::nullopt);
 }
 
-absl::optional<int> MyFrameGeneratorInterface::fps() const
+std::optional<int> MyFrameGeneratorInterface::fps() const
 {
-	return absl::nullopt;
+	return std::nullopt;
 }
 
 FrameGeneratorCapturerVideoTrackSource::FrameGeneratorCapturerVideoTrackSource(Config config, webrtc::Clock *clock, bool is_screencast,

--- a/MyFrameGeneratorInterface.h
+++ b/MyFrameGeneratorInterface.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "webrtc_compat.h"
+
 #include "pc/test/fake_audio_capture_module.h"
 #include "pc/test/fake_periodic_video_track_source.h"
 #include "pc/test/frame_generator_capturer_video_track_source.h"
@@ -16,7 +18,7 @@ public:
 
 	VideoFrameData NextFrame() override;
 
-	absl::optional<int> fps() const override;
+	std::optional<int> fps() const override;
 
 private:
 	const int m_width;

--- a/MyLogSink.h
+++ b/MyLogSink.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "webrtc_compat.h"
+
 #include "rtc_base/logging.h"
 
 #include <obs-module.h>

--- a/MyProducerAudioDeviceModule.h
+++ b/MyProducerAudioDeviceModule.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "webrtc_compat.h"
+
 #include "api/task_queue/default_task_queue_factory.h"
 #include "modules/audio_device/include/audio_device_default.h"
 #include "rtc_base/event.h"

--- a/scripts/build-libmediasoupclient-windows.cmd
+++ b/scripts/build-libmediasoupclient-windows.cmd
@@ -2,9 +2,8 @@
 
 set Z7_PATH="C:\Program Files\7-Zip"
 set ORIGINAL_WORK_DIR=%CD%
-set SCRIPT_FULL_FILENAME=%ORIGINAL_WORK_DIR%\%~n0%~x0
 set WEBRTC_FOLDER=%1
-set GIT_TAG=3.4.3
+set GIT_TAG=3.5.0
 set GIT_FOLDER_NAME=libmediasoupclient
 set GIT_FOLDER_PATH=%ORIGINAL_WORK_DIR%\%GIT_FOLDER_NAME%
 set BUILD_FOLDER_NAME=build
@@ -68,8 +67,6 @@ echo f | xcopy "%BUILD_FOLDER_PATH%\_deps\libsdptransform-build\RelWithDebInfo\s
 echo f | xcopy "%BUILD_FOLDER_PATH%\_deps\libsdptransform-build\RelWithDebInfo\sdptransform.pdb" "%PACKAGE_FOLDER_PATH%\lib\sdptransform.pdb" /yf
 
 echo f | xcopy "%BUILD_FOLDER_PATH%\_deps\libsdptransform-build\RelWithDebInfo\sdptransform.pdb" "%PACKAGE_FOLDER_PATH%\lib\sdptransform.pdb" /yf
-
-echo f | xcopy "%SCRIPT_FULL_FILENAME%" "%PACKAGE_FOLDER_PATH%" /yf
 
 :skip_copy
 

--- a/scripts/build-webrtc-windows.cmd
+++ b/scripts/build-webrtc-windows.cmd
@@ -1,8 +1,8 @@
 @echo off
 
-set MSVC_TOOL_PATH="C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\bin\Hostx64\x64"
+REM MSVC toolset below = installed version on this host (was 14.36.32532, not present); used by lib.exe combine.
+set MSVC_TOOL_PATH="C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64"
 set Z7_PATH="C:\Program Files\7-Zip"
-set SCRIPT_FULL_FILENAME=%ORIGINAL_WORK_DIR%\%~n0%~x0
 set ORIGINAL_WORK_DIR=%CD%
 set PATH=%ORIGINAL_WORK_DIR%\%DEPOT_TOOLS%\;%PATH%
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
@@ -10,8 +10,8 @@ set CHECKOUT_FOLDER_NAME=webrtc-checkout
 set CHECKOUT_FOLDER_PATH=%ORIGINAL_WORK_DIR%\%CHECKOUT_FOLDER_NAME%
 set SRC_FOLDER_NAME=src
 set SRC_FOLDER_PATH=%CHECKOUT_FOLDER_PATH%\%SRC_FOLDER_NAME%
-set WEBRTC_BRANCH=m120
-set WEBRTC_BRANCH_PATH=refs/remotes/branch-heads/6099
+set WEBRTC_BRANCH=m140
+set WEBRTC_BRANCH_PATH=refs/remotes/branch-heads/7339
 set BUILD_FOLDER_PATH=%SRC_FOLDER_PATH%\out\%WEBRTC_BRANCH%
 REM set PACKAGE_FOLDER_NAME=webrtc-%WEBRTC_BRANCH%-windows-x64
 set PACKAGE_FOLDER_NAME=webrtc_dist
@@ -63,10 +63,13 @@ if exist %BUILD_FOLDER_PATH%\ goto skip_webrtc_build
 
 echo ### Webrtc building...
 
+REM VERIFY @ M140: confirm gn still accepts every arg below (e.g. enable_iterator_debugging) at branch-heads/7339.
 call gn gen out\%WEBRTC_BRANCH% --args="is_debug=false is_component_build=false is_clang=true rtc_include_tests=true use_rtti=true rtc_build_examples=false use_custom_libcxx=false enable_iterator_debugging=false libcxx_is_shared=false rtc_build_tools=false use_lld=false treat_warnings_as_errors=false  use_custom_libcxx_for_host=false target_os=\"win\" target_cpu=\"x64\""
 if %errorlevel% neq 0 goto end
 
-call ninja -j6 -C out\%WEBRTC_BRANCH% 
+REM M140: build only the libs we package (deps pulled in automatically). Avoids compiling unneeded
+REM test code such as net_test_helpers, which fails under the newer MSVC STL (missing transitive <memory>).
+call ninja -j6 -C out\%WEBRTC_BRANCH% obj/webrtc.lib obj/api/video_codecs/builtin_video_encoder_factory.lib obj/api/video_codecs/builtin_video_decoder_factory.lib obj/media/rtc_internal_video_codecs.lib obj/media/rtc_simulcast_encoder_adapter.lib
 if %errorlevel% neq 0 goto end
 
 :skip_webrtc_build
@@ -83,7 +86,13 @@ echo \third_party\depot_tools\ >> excluded.txt
 
 mkdir %PACKAGE_FOLDER_PATH%
 xcopy "%SRC_FOLDER_PATH%\*.h" "%PACKAGE_FOLDER_PATH%" /sy /exclude:excluded.txt
+REM M140: abseil/webrtc headers also #include non-.h files (.inc etc.); ship them or downstream compiles fail (C1083).
+xcopy "%SRC_FOLDER_PATH%\*.inc" "%PACKAGE_FOLDER_PATH%" /sy /exclude:excluded.txt
+xcopy "%SRC_FOLDER_PATH%\*.hpp" "%PACKAGE_FOLDER_PATH%" /sy /exclude:excluded.txt
+xcopy "%SRC_FOLDER_PATH%\*.ipp" "%PACKAGE_FOLDER_PATH%" /sy /exclude:excluded.txt
+xcopy "%SRC_FOLDER_PATH%\*.def" "%PACKAGE_FOLDER_PATH%" /sy /exclude:excluded.txt
 
+REM VERIFY @ M140: these 12 test .cc paths must still exist and stay in sync with CMake webrtc-test_SOURCES.
 echo f | xcopy "%SRC_FOLDER_PATH%\api\test\create_frame_generator.cc" "%PACKAGE_FOLDER_PATH%\api\test\create_frame_generator.cc" /yf
 echo f | xcopy "%SRC_FOLDER_PATH%\media\base\fake_frame_source.cc" "%PACKAGE_FOLDER_PATH%\media\base\fake_frame_source.cc" /yf
 echo f | xcopy "%SRC_FOLDER_PATH%\pc\test\fake_audio_capture_module.cc" "%PACKAGE_FOLDER_PATH%\pc\test\fake_audio_capture_module.cc" /yf
@@ -97,14 +106,16 @@ echo f | xcopy "%SRC_FOLDER_PATH%\test\testsupport\file_utils_override.cc" "%PAC
 echo f | xcopy "%SRC_FOLDER_PATH%\test\testsupport\ivf_video_frame_generator.cc" "%PACKAGE_FOLDER_PATH%\test\testsupport\ivf_video_frame_generator.cc" /yf
 echo f | xcopy "%SRC_FOLDER_PATH%\test\vcm_capturer.cc" "%PACKAGE_FOLDER_PATH%\test\vcm_capturer.cc" /yf
 
+REM VERIFY @ M140: these obj\*.lib targets must exist (GN targets drift between milestones).
+REM field_trials + rtc_software_fallback_wrappers added for M140/libmediasoupclient 3.5.0 (link deps).
 %MSVC_TOOL_PATH%\lib.exe /out:"%PACKAGE_FOLDER_PATH%\webrtc.lib" ^
   "%BUILD_FOLDER_PATH%\obj\webrtc.lib" ^
   "%BUILD_FOLDER_PATH%\obj\api\video_codecs\builtin_video_encoder_factory.lib" ^
   "%BUILD_FOLDER_PATH%\obj\api\video_codecs\builtin_video_decoder_factory.lib" ^
   "%BUILD_FOLDER_PATH%\obj\media\rtc_internal_video_codecs.lib" ^
-  "%BUILD_FOLDER_PATH%\obj\media\rtc_simulcast_encoder_adapter.lib"
-
-echo f | xcopy "%SCRIPT_FULL_FILENAME%" "%PACKAGE_FOLDER_PATH%" /yf
+  "%BUILD_FOLDER_PATH%\obj\media\rtc_simulcast_encoder_adapter.lib" ^
+  "%BUILD_FOLDER_PATH%\obj\api\field_trials.lib" ^
+  "%BUILD_FOLDER_PATH%\obj\api\video_codecs\rtc_software_fallback_wrappers.lib"
 
 :skip_copying
 

--- a/scripts/libmediasoupclient.patch
+++ b/scripts/libmediasoupclient.patch
@@ -1,24 +1,25 @@
---- a/CMakeLists.txt	2024-07-11 20:38:24.134524700 -0400
-+++ b/CMakeLists.txt	2024-07-07 22:19:15.810910700 -0400
+Streamlabs build patch for libmediasoupclient 3.5.0 (Windows / MSVC static CRT).
+
+- Bump cmake_minimum_required to 3.20 so policy CMP0091 is NEW and the
+  CMAKE_MSVC_RUNTIME_LIBRARY setting below is actually honored.
+- Force the static MSVC runtime (/MT[d]) to match how the OBS plugin links.
+
+3.5.0 already sets CMAKE_CXX_STANDARD 20, so the old C++17->20 hunk is dropped.
+libmediasoupclient #189 (webrtc::PortInterface::Network vs webrtc::Network at M140)
+only breaks non-MSVC builds; the macOS pass must handle it in the non-MSVC flags branch.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 3.14)
 +cmake_minimum_required(VERSION 3.20)
- 
+
  project(mediasoupclient LANGUAGES CXX)
- 
-@@ -17,7 +17,7 @@
- )
- 
- # C++ standard requirements.
--set(CMAKE_CXX_STANDARD 17)
-+set(CMAKE_CXX_STANDARD 20)
- set(CMAKE_CXX_STANDARD_REQUIRED ON)
- 
- # Project options.
+
 @@ -56,6 +56,8 @@
  	endif()
  endif()
- 
+
 +set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 +
  if (${MEDIASOUPCLIENT_BUILD_TESTS})

--- a/webrtc_compat.h
+++ b/webrtc_compat.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// webrtc M140 (branch-heads/7339) moved a number of symbols out of the rtc:: and
+// cricket:: namespaces into webrtc::. These aliases keep the existing call sites
+// compiling without a wholesale rename. Include this before any rtc::/cricket:: use.
+//
+// Only namespace moves are handled here; signature changes are fixed at the call sites.
+
+#include <optional>
+
+#include "api/audio_options.h"
+#include "api/make_ref_counted.h"
+#include "api/scoped_refptr.h"
+#include "api/video/video_sink_interface.h"
+#include "api/video/video_source_interface.h"
+#include "rtc_base/crypto_random.h"
+#include "rtc_base/event.h"
+#include "rtc_base/logging.h"
+#include "rtc_base/ref_counted_object.h"
+#include "rtc_base/thread.h"
+
+namespace rtc {
+using webrtc::CreateRandomId;
+using webrtc::CreateRandomUuid;
+using webrtc::Event;
+using webrtc::LoggingSeverity;
+using webrtc::LogMessage;
+using webrtc::LogSink;
+using webrtc::RefCountedObject;
+using webrtc::scoped_refptr;
+using webrtc::Thread;
+using webrtc::VideoSinkInterface;
+using webrtc::VideoSinkWants;
+using webrtc::VideoSourceInterface;
+} // namespace rtc
+
+namespace cricket {
+using webrtc::AudioOptions;
+} // namespace cricket


### PR DESCRIPTION
Upgrades the plugin from libmediasoupclient 3.4.3 / libwebrtc m120 to **3.5.0 / M140 (branch-heads/7339)**. Windows x64; macOS scripts are a follow-up.

## Build recipe (`scripts/`)
- `build-webrtc-windows.cmd`: m140 / branch-heads/7339; builds only the 5 packaged targets (the full `ninja` fails on M140 test code under the newer MSVC STL); packages `.inc`/`.hpp`/`.ipp`/`.def` headers (abseil needs `.inc`); combines **7** libs (added `field_trials` + `rtc_software_fallback_wrappers`, required by 3.5.0); MSVC toolset 14.44.
- `build-libmediasoupclient-windows.cmd`: tag 3.5.0.
- `libmediasoupclient.patch`: regenerated for 3.5.0 (static MSVC runtime + cmake_min 3.20; dropped the now-redundant C++17→20 hunk).

## Source adaptation (M140 API)
- `webrtc_compat.h` re-aliases the `rtc::`/`cricket::` symbols moved to `webrtc::` (scoped_refptr, Thread, Event, AudioOptions, …).
- `make_ref_counted` (scoped_refptr ctor is now `explicit`); `CreateVideoTrack(source, label)` reorder; `CreateAudioDeviceModule(env, …)` replacing `AudioDeviceModule::Create`; `std::optional`/`std::nullopt`; manual `Interleave` (now view-based); `COMPILE_WARNING_AS_ERROR OFF` on the webrtc-coupled targets.

Builds + links cleanly (RelWithDebInfo) against the rebuilt `webrtc_dist` / `libmediasoupclient_dist`.
