### PR TITLE
Fix macOS Xcode 26.4 build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,10 @@ if(MSVC)
     target_compile_definitions(mediasoup-connector PRIVATE _SILENCE_CXX20_DEPRECATION_WARNING)
 
 elseif(APPLE)
-	target_compile_options(mediasoup-connector PRIVATE "-Wno-unused-parameter")
+	target_compile_options(mediasoup-connector PRIVATE "-Wno-unused-parameter" "-Wno-deprecated-literal-operator")
+	set_target_xcode_properties(
+		mediasoup-connector
+		PROPERTIES WARNING_CFLAGS "-Wvla -Wformat-security -Wno-error=shorten-64-to-32 -Wno-error=deprecated-literal-operator")
 endif()
 
 


### PR DESCRIPTION
### Summary
- Suppress the deprecated literal operator warning for Apple builds.
- Add Xcode warning flags so Xcode 26.4 does not promote this warning to a build error.

### Context
The macOS OBS build is currently blocked by newer Xcode diagnostics in the mediasoup connector target. This keeps the warning policy narrow to Apple builds and avoids changing other platforms.