### PR TITLE
Update MacOS build scripts for webrtc/libmediasoup update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if(MSVC)
 endif()
 
 if(APPLE)
-	list(APPEND webrtc_COMMON_COMPILE_DEFS WEBRTC_POSIX)
+	list(APPEND webrtc_COMMON_COMPILE_DEFS WEBRTC_POSIX WEBRTC_MAC)
 endif()
 
 # ----------------
@@ -92,7 +92,7 @@ if(MSVC)
     target_compile_definitions(webrtc-testlibs PRIVATE _SILENCE_CXX20_IS_POD_DEPRECATION_WARNING)
 elseif(APPLE)
     # Apple Clang specific warning suppressions
-    target_compile_options(webrtc-testlibs PRIVATE "-Wno-unused-parameter")
+    target_compile_options(webrtc-testlibs PRIVATE "-Wno-unused-parameter" "-Wno-nullability-completeness")
     target_compile_options(webrtc-testlibs PRIVATE "-include" "${CMAKE_CURRENT_SOURCE_DIR}/absl_lifetime_patch.h")
 else()
     # GCC/Clang on other systems
@@ -158,11 +158,11 @@ if(MSVC)
     target_compile_definitions(mediasoup-connector PRIVATE _SILENCE_CXX20_DEPRECATION_WARNING)
 
 elseif(APPLE)
-	target_compile_options(mediasoup-connector PRIVATE "-Wno-unused-parameter" "-Wno-deprecated-literal-operator")
+	target_compile_options(mediasoup-connector PRIVATE "-Wno-unused-parameter" "-Wno-deprecated-literal-operator" "-Wno-nullability-completeness")
 	target_compile_options(mediasoup-connector PRIVATE "-include" "${CMAKE_CURRENT_SOURCE_DIR}/absl_lifetime_patch.h")
 	set_target_xcode_properties(
 		mediasoup-connector
-		PROPERTIES WARNING_CFLAGS "-Wvla -Wformat-security -Wno-error=shorten-64-to-32 -Wno-error=deprecated-literal-operator")
+		PROPERTIES WARNING_CFLAGS "-Wvla -Wformat-security -Wno-error=shorten-64-to-32 -Wno-error=deprecated-literal-operator -Wno-nullability-completeness")
 endif()
 
 

--- a/scripts/build-libmediasoupclient-macos.zsh
+++ b/scripts/build-libmediasoupclient-macos.zsh
@@ -5,7 +5,7 @@
 # 3. ./build-libmediasoupclient-macos.zsh --architecture=arm64 --webrtc-folder=THE_COMBINED_WEBRTC_INCLUDE_AND_LIB_FOLDER
 # 4. ./build-libmediasoupclient-macos.zsh --architecture=x86_64 --webrtc-folder=THE_COMBINED_WEBRTC_INCLUDE_AND_LIB_FOLDER
 
-download_libmediasoupclient() {    
+download_libmediasoupclient() {
     # Check if the webrtc folder exists
     if [ -d "${GIT_FOLDER}" ]
     then
@@ -61,7 +61,7 @@ build_libmediasoupclient() {
     then
         echo "### The '${BUILD_FOLDER}' folder exists. Configuring will be skiped. Remove the folder if you want to configure from scratch."
     else
-        cmake . -B"${BUILD_FOLDER}" -DLIBWEBRTC_INCLUDE_PATH="${WEBRTC_FOLDER}" -DLIBWEBRTC_BINARY_PATH="${WEBRTC_FOLDER}" -DCMAKE_OSX_ARCHITECTURES="${ARCHITECTURE}" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MIN_MACOS_VERSION}
+        cmake . -B"${BUILD_FOLDER}" -DLIBWEBRTC_INCLUDE_PATH="${WEBRTC_FOLDER}" -DLIBWEBRTC_BINARY_PATH="${WEBRTC_FOLDER}" -DCMAKE_OSX_ARCHITECTURES="${ARCHITECTURE}" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MIN_MACOS_VERSION} -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         if [ $? -ne 0 ]
         then
             echo "### Could not configure to build for ${ARCHITECTURE}"
@@ -137,7 +137,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "${WEBRTC_FOLDER}" ]; then
-    echo "### The webrtc include folder is not set. Please specify --webrtc-include-folder=..."
+    echo "### The webrtc include folder is not set. Please specify --webrtc-folder=..."
     exit 1
 fi
 
@@ -147,7 +147,7 @@ GIT_FOLDER_NAME=libmediasoupclient
 GIT_FOLDER=${PWD}/${GIT_FOLDER_NAME}
 BUILD_FOLDER_NAME=build-${ARCHITECTURE}
 BUILD_FOLDER=${GIT_FOLDER}/${BUILD_FOLDER_NAME}
-GIT_TAG=3.4.3
+GIT_TAG=3.5.0
 
 # Check if git is available
 if ! command -v git &> /dev/null

--- a/scripts/build-webrtc-macos.zsh
+++ b/scripts/build-webrtc-macos.zsh
@@ -36,7 +36,7 @@ download_webrtc() {
     # fetch --nohooks webrtc
     # gclient sync
     # cd src
-    # git checkout -b m120 refs/remotes/branch-heads/6099
+    # git checkout -b m140 refs/remotes/branch-heads/7339
     # gclient sync
 
     if [ -d "${SRC_PARENT_FOLDER}" ]
@@ -175,18 +175,43 @@ package_webrtc() {
     mkdir -p "${PACKAGE_FOLDER}"
 
     # Copy libs
+    echo "### Collecting object files from thin archives ..."
+    THIN_LIBS=(
+        "${BUILD_FOLDER}/obj/api/video_codecs/libbuiltin_video_decoder_factory.a"
+        "${BUILD_FOLDER}/obj/api/video_codecs/libbuiltin_video_encoder_factory.a"
+        "${BUILD_FOLDER}/obj/media/librtc_internal_video_codecs.a"
+        "${BUILD_FOLDER}/obj/media/librtc_simulcast_encoder_adapter.a"
+        "${BUILD_FOLDER}/obj/api/libfield_trials.a"
+        "${BUILD_FOLDER}/obj/api/video_codecs/librtc_software_fallback_wrappers.a"
+    )
+    EXTRA_OBJS=()
+    for LIB in "${THIN_LIBS[@]}"; do
+        if [ ! -f "${LIB}" ]
+        then
+            echo "### Missing required library: ${LIB}"
+            exit 1
+        fi
+        LIB_OBJS=()
+        while IFS= read -r OBJ; do
+            [[ -n "${OBJ}" ]] && LIB_OBJS+=("${OBJ}")
+        done < <(python3 "${SCRIPT_PATH%/*}/thin_archive_objs.py" "${LIB}")
+        if [ ${#LIB_OBJS[@]} -eq 0 ]
+        then
+            EXTRA_OBJS+=("${LIB}")
+        else
+            EXTRA_OBJS+=("${LIB_OBJS[@]}")
+        fi
+    done
+
     echo "### Copying libraries ..."
     libtool -static -o "${PACKAGE_FOLDER}/libwebrtc.a" \
         "${BUILD_FOLDER}/obj/libwebrtc.a" \
-        "${BUILD_FOLDER}/obj/api/video_codecs/libbuiltin_video_decoder_factory.a" \
-        "${BUILD_FOLDER}/obj/api/video_codecs/libbuiltin_video_encoder_factory.a" \
-        "${BUILD_FOLDER}/obj/media/librtc_internal_video_codecs.a" \
-        "${BUILD_FOLDER}/obj/media/librtc_simulcast_encoder_adapter.a"
+        "${EXTRA_OBJS[@]}"
 
     # Copy includes
     echo "### Copying includes ..."
     cd "${GIT_FOLDER}"
-    find . -name '*.h' -not -path "./out/*" -not -path "./third_party/depot_tools/*" | cpio -pdm "${PACKAGE_FOLDER}"
+    find . \( -name '*.h' -o -name '*.inc' \) -not -path "./out/*" -not -path "./third_party/depot_tools/*" | cpio -pdm "${PACKAGE_FOLDER}"
 
     # Copy some sources
     echo "### Copying some sources ..."
@@ -236,8 +261,8 @@ SRC_PARENT_FOLDER_NAME=webrtc-checkout
 SRC_PARENT_FOLDER=${PWD}/${SRC_PARENT_FOLDER_NAME}
 GIT_FOLDER_NAME=src
 GIT_FOLDER=${SRC_PARENT_FOLDER}/${GIT_FOLDER_NAME}
-GIT_REFS=refs/remotes/branch-heads/6099
-VERSION_NAME=m120
+GIT_REFS=refs/remotes/branch-heads/7339
+VERSION_NAME=m140
 BUILD_FOLDER_NAME=${VERSION_NAME}-${ARCHITECTURE}
 BUILD_FOLDER_REL=out/${BUILD_FOLDER_NAME}
 BUILD_FOLDER=${GIT_FOLDER}/${BUILD_FOLDER_REL}


### PR DESCRIPTION
* Update build scripts to use webrtc-140 & libmediasoup 3.5.0
* Add .py script which will dynamically add the required files to the `libwebrtc.a` static lib